### PR TITLE
Changed directory name in Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repo contains the source code and documentation powering [reactjs.org](http
 
 ### Installation
 
-1. `cd reactjs.org` to go into the project root
+1. `cd gu.reactjs.org` to go into the project root
 1. `yarn` to install the website's npm dependencies
 
 ### Running locally


### PR DESCRIPTION
Changed directory name in Installation guide :
```diff
- cd reactjs.org
+ cd gu.reactjs.org
```



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
